### PR TITLE
Updated scripts for PS/LR/AI CC 2015

### DIFF
--- a/applescript/com.adobe.InDesign.scpt
+++ b/applescript/com.adobe.InDesign.scpt
@@ -1,3 +1,3 @@
-tell application "Adobe InDesign CC 2014"
-    return the name of the (get active document)
+tell application id "com.adobe.InDesign"
+    return name of (get active document)
 end tell

--- a/applescript/com.adobe.Lightroom6.scpt
+++ b/applescript/com.adobe.Lightroom6.scpt
@@ -1,0 +1,20 @@
+tell application id "com.adobe.Lightroom6"
+	set theString to the path of (get front document)
+	set thePieces to my explode("/", theString)
+	set theFilename to the last item in thePieces
+end tell
+
+on explode(delimiter, input)
+	local delimiter, input, ASTID
+	set ASTID to AppleScript's text item delimiters
+	try
+		set AppleScript's text item delimiters to delimiter
+		set input to text items of input
+		set AppleScript's text item delimiters to ASTID
+		return input --> list
+	on error eMsg number eNum
+		set AppleScript's text item delimiters to ASTID
+		error "Can't explode: " & eMsg number eNum
+	end try
+end explode
+

--- a/applescript/com.adobe.Photoshop.scpt
+++ b/applescript/com.adobe.Photoshop.scpt
@@ -1,3 +1,3 @@
-tell application "Adobe Photoshop CC 2014"
+tell application id "com.adobe.Photoshop"
 	return name of current document
 end tell

--- a/applescript/com.adobe.illustrator.scpt
+++ b/applescript/com.adobe.illustrator.scpt
@@ -1,3 +1,3 @@
-tell application "Adobe Illustrator"
-	return the name of the current document
+tell application id "com.adobe.Illustrator"
+	return name of current document
 end tell

--- a/applescript/com.adobe.illustrator.scpt
+++ b/applescript/com.adobe.illustrator.scpt
@@ -1,3 +1,3 @@
-tell application id "com.adobe.Illustrator"
+tell application id "com.adobe.illustrator"
 	return name of current document
 end tell


### PR DESCRIPTION
`tell application id com.application.BundleID` seems to be a bit more bulletproof than using the app name.
