### PR TITLE
Added support for Scapple and Eloquent

### DIFF
--- a/applescript/com.literatureandlatte.scapple.scpt
+++ b/applescript/com.literatureandlatte.scapple.scpt
@@ -1,0 +1,7 @@
+tell application "System Events"
+	tell process "Scapple"
+		tell (1st window whose value of attribute "AXMain" is true)
+			return the value of attribute "AXTitle"
+		end tell
+	end tell
+end tell

--- a/applescript/org.crosswire.Eloquent.scpt
+++ b/applescript/org.crosswire.Eloquent.scpt
@@ -1,0 +1,16 @@
+to split(someText, delimiter)
+	set AppleScript's text item delimiters to delimiter
+	set someText to someText's text items
+	set AppleScript's text item delimiters to {""} --> restore delimiters to default value
+	return someText
+end split
+
+tell application "System Events"
+	tell process "Eloquent"
+		tell (1st window whose value of attribute "AXMain" is true)
+			set theTitle to the value of attribute "AXTitle"
+		end tell
+	end tell
+end tell
+set verse to item 3 of (split(theTitle, "- "))
+return verse


### PR DESCRIPTION
Hi,

Just added support for Scapple and Eloquent. Scapple is a mindmap/thought processor from the people of Scrivener. Eloquent is a Bible search/study tool program. The Eloquent fixed the title so that it makes the notes based on the current verse of the Bible. Very handy!
